### PR TITLE
[SFDCENG-610] getBlob is returning a closed InputStream

### DIFF
--- a/src/main/java/org/springframework/social/salesforce/api/impl/SObjectsTemplate.java
+++ b/src/main/java/org/springframework/social/salesforce/api/impl/SObjectsTemplate.java
@@ -5,17 +5,16 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
-import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.http.ResponseEntity;
 import org.springframework.social.salesforce.api.SObjectDetail;
 import org.springframework.social.salesforce.api.SObjectOperations;
 import org.springframework.social.salesforce.api.SObjectSummary;
 import org.springframework.social.salesforce.api.Salesforce;
 import org.springframework.social.support.URIBuilder;
 import org.springframework.util.StringUtils;
-import org.springframework.web.client.ResponseExtractor;
 import org.springframework.web.client.RestTemplate;
 
-import java.io.IOException;
+import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -69,13 +68,12 @@ public class SObjectsTemplate extends AbstractSalesForceOperations<Salesforce> i
     @Override
     public InputStream getBlob(String name, String id, String field) {
         requireAuthorization();
-        return restTemplate.execute(api.getBaseUrl() + "/{version}/sobjects/{name}/{id}/{field}",
-                HttpMethod.GET, null, new ResponseExtractor<InputStream>() {
-                    @Override
-                    public InputStream extractData(ClientHttpResponse response) throws IOException {
-                        return response.getBody();
-                    }
-                }, API_VERSION, name, id, field);
+        HttpHeaders headers = new HttpHeaders();
+        HttpEntity<String> entity = new HttpEntity<>(headers);
+        ResponseEntity<byte[]> response =  restTemplate.exchange(
+                api.getBaseUrl() + "/{version}/sobjects/{name}/{id}/{field}", HttpMethod.GET, entity, byte[].class,
+                API_VERSION, name, id, field);
+        return new ByteArrayInputStream(response.getBody());
     }
 
     @Override

--- a/src/main/java/org/springframework/social/salesforce/api/impl/SalesforceTemplate.java
+++ b/src/main/java/org/springframework/social/salesforce/api/impl/SalesforceTemplate.java
@@ -6,6 +6,8 @@ import com.fasterxml.jackson.databind.type.CollectionType;
 import com.fasterxml.jackson.databind.type.TypeFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.ByteArrayHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
@@ -24,6 +26,7 @@ import org.springframework.social.salesforce.api.impl.json.SalesforceModule;
 import org.springframework.web.client.RestTemplate;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -204,15 +207,24 @@ public class SalesforceTemplate extends AbstractOAuth2ApiBinding implements Sale
         messageConverters.add(new StringHttpMessageConverter());
         messageConverters.add(getFormMessageConverter());
         messageConverters.add(this.getJsonMessageConverter2());
-        messageConverters.add(getByteArrayMessageConverter());
+        messageConverters.add(this.getByteArrayMessageConverter());
         return messageConverters;
     }
 
-    protected MappingJackson2HttpMessageConverter getJsonMessageConverter2() {
+    protected MappingJackson2HttpMessageConverter getJsonMessageConverter2()
+    {
         MappingJackson2HttpMessageConverter converter = new MappingJackson2HttpMessageConverter();
         objectMapper = new ObjectMapper();
         objectMapper.registerModule(new SalesforceModule());
         converter.setObjectMapper(objectMapper);
+        return converter;
+    }
+
+    @Override
+    protected ByteArrayHttpMessageConverter getByteArrayMessageConverter()
+    {
+        ByteArrayHttpMessageConverter converter = new ByteArrayHttpMessageConverter();
+        converter.setSupportedMediaTypes(Arrays.asList(MediaType.ALL));
         return converter;
     }
 

--- a/src/test/java/org/springframework/social/salesforce/api/impl/SObjectsTemplateTest.java
+++ b/src/test/java/org/springframework/social/salesforce/api/impl/SObjectsTemplateTest.java
@@ -72,6 +72,7 @@ public class SObjectsTemplateTest extends AbstractSalesforceTest {
 
     @Test
     public void getBlob() throws IOException {
+        responseHeaders.remove("content-type");
         mockServer.expect(requestTo("https://na7.salesforce.com/services/data/" + AbstractSalesForceOperations.API_VERSION + "/sobjects/Account/xxx/avatar"))
                 .andExpect(method(GET))
                 .andRespond(withResponse(new ByteArrayResource("does-not-matter".getBytes("UTF-8")), responseHeaders));


### PR DESCRIPTION
-override ByteArrayHttpMessageConverter to allow all media types
-change extractor to use the byteArray message converter in the RestRemplate
-to keep the existing method signature as InputStream return byteArray as byteArrayInputStream
-remove default content-type header used in other tests to allow return on non json content.