### PR TITLE
SFDCENG-748 : Update dependencies for Alfresco/spring-social-salesforce

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -314,14 +314,13 @@
     </scm>
 
     <distributionManagement>
-        <!-- Public repositories -->
         <repository>
-            <id>alfresco-public</id>
-            <url>https://artifacts.alfresco.com/nexus/content/repositories/public</url>
+            <id>alfresco-internal</id>
+            <url>https://artifacts.alfresco.com/nexus/content/repositories/thirdparty</url>
         </repository>
         <snapshotRepository>
-            <id>alfresco-public-snapshots</id>
-            <url>https://artifacts.alfresco.com/nexus/content/repositories/public-snapshots</url>
+            <id>alfresco-snapshots</id>
+            <url>https://artifacts.alfresco.com/nexus/content/repositories/snapshots</url>
         </snapshotRepository>
     </distributionManagement>
 </project>


### PR DESCRIPTION
Replace alfresco 'public' repositories with 'thirdparty'.